### PR TITLE
Remove empty format precision specifier

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -124,7 +124,7 @@ impl Into<f32> for Float32FitnessValue {
 impl Display for Float32FitnessValue {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         // display with maximum precision, aka as many digits as possible
-        write!(f, "{:.}", self.0)
+        write!(f, "{}", self.0)
     }
 }
 


### PR DESCRIPTION
A format precision specifier consisting of a dot and no number actually does nothing and has no specified meaning. Currently this is silently ignored, but it may turn into a warning or error.

See https://github.com/rust-lang/rust/issues/131159 and https://github.com/rust-lang/rust/pull/136638

Please leave a comment there if you have any opinion about this. If you remember why this was written this way that could help improve the diagnostics rustc gives.